### PR TITLE
Allow default namespace to be specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - TBA
+## Added
+- Allow to override the default namespace for jobs triggered via the HTTP API
+  endpoint
 
 ## [0.3.2] - 2023-03-21
 ## Fixed

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -54,6 +54,7 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var webServerAddr string
+	var defaultNamespace string
 	flag.StringVar(&webServerAddr, "web-server-bind-address", ":8000",
 		"The address the web server endpoint binds to.")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080",
@@ -63,6 +64,8 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&defaultNamespace, "default-namespace", "default",
+		"The default namespace to use when no namespace is specified when invoking a job via HTTP.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -113,7 +116,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := mgr.Add(http.NewServer(webServerAddr, mgr.GetClient())); err != nil {
+	if err := mgr.Add(http.NewServer(webServerAddr, defaultNamespace, mgr.GetClient())); err != nil {
 		setupLog.Error(err, "Error running Web Server")
 		os.Exit(1)
 	}

--- a/pkg/http/execute_job_handler.go
+++ b/pkg/http/execute_job_handler.go
@@ -15,8 +15,6 @@ import (
 	"github.com/ivanvc/dispatcher/pkg/api/v1alpha1"
 )
 
-const defaultNamespace = "default"
-
 type executeJobHandler struct {
 	*Server
 }
@@ -34,7 +32,7 @@ func (e *executeJobHandler) handle(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	log := ctrllog.FromContext(ctx)
 
-	name, ns, err := getNameAndNamespace(req.URL.Path)
+	name, ns, err := getNameAndNamespace(req.URL.Path, e.defaultNamespace)
 	if err != nil {
 		log.Error(err, "Error getting name and namespace")
 		w.WriteHeader(http.StatusNotAcceptable)
@@ -60,7 +58,7 @@ func (e *executeJobHandler) handle(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 }
 
-func getNameAndNamespace(path string) (name, namespace string, err error) {
+func getNameAndNamespace(path, defaultNamespace string) (name, namespace string, err error) {
 	if n := strings.Split(strings.TrimPrefix(path, "/execute/"), "/"); len(n[0]) == 0 || len(n) > 2 {
 		return "", "", errors.New("Empty job name")
 	} else if len(n) > 1 {

--- a/pkg/http/execute_job_handler_test.go
+++ b/pkg/http/execute_job_handler_test.go
@@ -19,7 +19,7 @@ func TestGetNameAndNamespaceWithAnError(t *testing.T) {
 		"/execute/a/b/c",
 	}
 	for _, tc := range tt {
-		if _, _, err := getNameAndNamespace(tc); err == nil {
+		if _, _, err := getNameAndNamespace(tc, "default"); err == nil {
 			t.Errorf("Expecting error with input %q, got nothing", tc)
 			return
 		}
@@ -32,7 +32,7 @@ func TestGetNameAndNamespaceWithoutAnError(t *testing.T) {
 		[]string{"/execute/a/b", "a", "b"},
 	}
 	for _, tc := range tt {
-		name, ns, err := getNameAndNamespace(tc[0])
+		name, ns, err := getNameAndNamespace(tc[0], "default")
 		if err != nil {
 			t.Error(err)
 			return

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -11,6 +11,7 @@ import (
 type Server struct {
 	*http.Server
 	client.Client
+	defaultNamespace string
 }
 
 // NeedLeaderElection implements the LeaderElectionRunnable interface, which
@@ -19,8 +20,8 @@ func (*Server) NeedLeaderElection() bool {
 	return false
 }
 
-func NewServer(address string, client client.Client) *Server {
-	return &Server{&http.Server{Addr: address}, client}
+func NewServer(address, defaultNamespace string, client client.Client) *Server {
+	return &Server{&http.Server{Addr: address}, client, defaultNamespace}
 }
 
 func (s *Server) Start(ctx context.Context) error {


### PR DESCRIPTION
The default namespace can now be specified. This is used when there's an HTTP job execution and the namespace is not specified.