### PR TITLE
Deduplicate created jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - Allow the controller manager to write events
 - Improve error messages when status fails to update
+- Get the Job from the JobExecution using a the controller-uid label rather than
+  the status
 
 ## [0.4.0] - 2023-07-27
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 - Allow the controller manager to write events
+- Improve error messages when status fails to update
 
 ## [0.4.0] - 2023-07-27
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - TBA
 
+## Fixed
+- Allow the controller manager to write events
+
 ## [0.4.0] - 2023-07-27
 ## Added
 - Allow to override the default namespace for jobs triggered via the HTTP API

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,13 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - batch
   resources:
   - jobs

--- a/pkg/controllers/jobexecution_controller.go
+++ b/pkg/controllers/jobexecution_controller.go
@@ -80,6 +80,7 @@ type JobExecutionReconciler struct {
 //+kubebuilder:rbac:groups=dispatcher.ivan.vc,resources=jobexecutions/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=dispatcher.ivan.vc,resources=jobexecutions/finalizers,verbs=update
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/pkg/controllers/jobexecution_controller.go
+++ b/pkg/controllers/jobexecution_controller.go
@@ -179,14 +179,15 @@ func (r *JobExecutionReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			Message: "Job created, waiting to be executed",
 		})
 
+		r.Recorder.Eventf(je, corev1.EventTypeNormal, "Created", "Job %s created", createdJob.Name)
+		log.Info("Created Job, requeueing")
+		jobExecutionsTotal.Inc()
+
 		if err := r.Status().Update(ctx, je); err != nil {
 			log.Error(err, "Failed to update JobExecution status when creating job")
 			return ctrl.Result{}, err
 		}
 
-		r.Recorder.Eventf(je, corev1.EventTypeNormal, "Created", "Job %s created", createdJob.Name)
-		log.Info("Created Job, requeueing")
-		jobExecutionsTotal.Inc()
 		return ctrl.Result{Requeue: true}, nil
 	}
 

--- a/pkg/controllers/jobexecution_controller.go
+++ b/pkg/controllers/jobexecution_controller.go
@@ -108,11 +108,11 @@ func (r *JobExecutionReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			Message: "Starting reconciliation",
 		})
 		if err := r.Status().Update(ctx, je); err != nil {
-			log.Error(err, "Failed to update JobExecution status")
+			log.Error(err, "Failed to set initial JobExecution status")
 			return ctrl.Result{}, err
 		}
 
-		// Re-fetch JobExecution to avoid having to re-run reocnciliation loop
+		// Re-fetch JobExecution to avoid having to re-run reconciliation loop
 		if err := r.Get(ctx, req.NamespacedName, je); err != nil {
 			log.Error(err, "Failed to re-fetch JobExecution")
 			return ctrl.Result{}, err
@@ -128,7 +128,7 @@ func (r *JobExecutionReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			Message: "Failed fetching JobTemplate",
 		})
 		if err := r.Status().Update(ctx, je); err != nil {
-			log.Error(err, "Failed to update JobExecution status")
+			log.Error(err, "Failed to set JobExecution status to failed fetching job template")
 			return ctrl.Result{}, err
 		}
 
@@ -186,7 +186,7 @@ func (r *JobExecutionReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		je.Status.Job = *jobRef
 
 		if err := r.Status().Update(ctx, je); err != nil {
-			log.Error(err, "Failed to update JobExecution status")
+			log.Error(err, "Failed to update JobExecution status when creating job")
 			return ctrl.Result{}, err
 		}
 

--- a/pkg/controllers/jobexecution_controller_test.go
+++ b/pkg/controllers/jobexecution_controller_test.go
@@ -213,14 +213,11 @@ var _ = Describe("JobExecution controller", func() {
 		By("Creating a v1alpha1 JobTemplate")
 		jobTemplateName := "v1alpha1-jobtemplate"
 		v1alpha1JobTemplate := new(dispatcherv1alpha1.JobTemplate)
-		fmt.Println("v1beta1", jobTemplate)
-		fmt.Println("v1alpha1 before", v1alpha1JobTemplate)
 		v1alpha1JobTemplate.ConvertFrom(jobTemplate)
 		v1alpha1JobTemplate.ObjectMeta = metav1.ObjectMeta{
 			Name:      jobTemplateName,
 			Namespace: namespaceName,
 		}
-		fmt.Println("v1alpha1 after", v1alpha1JobTemplate)
 
 		err := k8sClient.Create(ctx, v1alpha1JobTemplate)
 		Expect(err).To(Not(HaveOccurred()))


### PR DESCRIPTION
Revert getting JobExecution's job. Use labels rather than status references, as changing the JobExecution's status may fail.